### PR TITLE
small typo in macos support

### DIFF
--- a/chb/util/Config.py
+++ b/chb/util/Config.py
@@ -58,7 +58,7 @@ class Config():
             self.chx86_analyze = os.path.join(self.linuxdir,'chx86_analyze')
 
         elif self.platform == 'macOS':
-            self,macOSdir = os.path.join(self.binariesdir,'macOS')
+            self.macOSdir = os.path.join(self.binariesdir,'macOS')
             self.chx86_analyze = os.path.join(self.macOSdir,'chx86_analyze')
 
         # optional: set architecture-specific analysis targets to provide


### PR DESCRIPTION
Note that even with this fix the example code in the readme fails to run on macos, but I'll file a separate issue for that since this change seems pretty straight forward and correct.