### PR TITLE
AppAccess doesn't need architechture fields

### DIFF
--- a/chb/app/AppAccess.py
+++ b/chb/app/AppAccess.py
@@ -62,14 +62,12 @@ class AppAccess(ABC, Generic[HeaderTy]):
             path: str,
             filename: str,
             fileformat: Type[HeaderTy],
-            deps: List[str] = [],
-            arch: str = "x86") -> None:
+            deps: List[str] = []) -> None:
         """Initializes access to analysis results."""
         self._path = path
         self._filename = filename
         self._deps = deps  # list of summary jars registered as dependencies
         self._header_ty: Type[HeaderTy] = fileformat  # currently supported: elf, pe
-        self._arch = arch  # currently supported: arm, mips, x86
 
         self._userdata: Optional[UserData] = None
 
@@ -106,24 +104,8 @@ class AppAccess(ABC, Generic[HeaderTy]):
     # Architecture and file format ---------------------------------------------
 
     @property
-    def architecture(self) -> str:
-        return self._arch
-
-    @property
     def fileformat(self) -> str:
         return self._header_ty.fmt_name()
-
-    @property
-    def arm(self) -> bool:
-        return self.architecture == "arm"
-
-    @property
-    def mips(self) -> bool:
-        return self.architecture == "mips"
-
-    @property
-    def x86(self) -> bool:
-        return self.architecture == "x86"
 
     @property
     def elf(self) -> bool:

--- a/chb/arm/ARMAccess.py
+++ b/chb/arm/ARMAccess.py
@@ -43,9 +43,8 @@ class ARMAccess(AppAccess[HeaderTy]):
             path: str,
             filename: str,
             fileformat: Type[HeaderTy],
-            deps: List[str] = [],
-            arch: str = "arm") -> None:
-        AppAccess.__init__(self, path, filename, fileformat, deps, arch)
+            deps: List[str] = []) -> None:
+        AppAccess.__init__(self, path, filename, fileformat, deps)
         self._armd: Optional[ARMDictionary] = None
         self._functions: Dict[str, ARMFunction] = {}
 

--- a/chb/cmdline/commandutil.py
+++ b/chb/cmdline/commandutil.py
@@ -128,24 +128,23 @@ def get_app(path: str, xfile: str, xinfo: XI.XInfo) -> AppAccess:
     arch = xinfo.architecture
     format = get_format(xinfo.format)
     if arch == "x86":
-        return X86Access(path, xfile, fileformat=format, arch=arch)
+        return X86Access(path, xfile, fileformat=format)
     elif arch == "mips":
-        return MIPSAccess(path, xfile, fileformat=format, arch=arch)
+        return MIPSAccess(path, xfile, fileformat=format)
     elif arch == "arm":
-        return ARMAccess(path, xfile, fileformat=format, arch=arch)
+        return ARMAccess(path, xfile, fileformat=format)
     else:
         raise UF.CHBError("Archicture " + arch + " not yet supported")
 
 
 def get_asm(app: AppAccess) -> Assembly:
-    if app.mips:
+    if isinstance(app, MIPSAccess):
         app = cast(MIPSAccess, app)
         return MIPSAssembly(app, UF.get_mips_asm_xnode(app.path, app.filename))
-    elif app.arm:
-        app = cast(ARMAccess, app)
+    elif isinstance(app, ARMAccess):
         return ARMAssembly(app, UF.get_arm_asm_xnode(app.path, app.filename))
     else:
-        print_error("Simulation not yet supported for " + app.architecture)
+        print_error("Simulation not yet supported for " + app.__class__.__name__)
         exit(1)
 
 

--- a/chb/cmdline/simulatecmds.py
+++ b/chb/cmdline/simulatecmds.py
@@ -146,5 +146,5 @@ def simulate_function_cmd(args: argparse.Namespace) -> NoReturn:
     else:
         UC.print_error(
             "Simulation not yet implemented for "
-            + app.architecture)
+            + app.__class__.__name__)
         exit(1)

--- a/chb/mips/MIPSAccess.py
+++ b/chb/mips/MIPSAccess.py
@@ -46,9 +46,8 @@ class MIPSAccess(AppAccess[HeaderTy]):
             path: str,
             filename: str,
             fileformat: Type[HeaderTy],
-            deps: List[str] = [],
-            arch: str = "mips") -> None:
-        AppAccess.__init__(self, path, filename, fileformat, deps, arch)
+            deps: List[str] = []) -> None:
+        AppAccess.__init__(self, path, filename, fileformat, deps)
         self._mipsd: Optional[MIPSDictionary] = None
         self._functions: Dict[str, MIPSFunction] = {}
 

--- a/chb/x86/X86Access.py
+++ b/chb/x86/X86Access.py
@@ -46,9 +46,8 @@ class X86Access(AppAccess[HeaderTy]):
             path: str,
             filename: str,
             fileformat: Type[HeaderTy],
-            deps: List[str] = [],
-            arch: str = "x86") -> None:
-        AppAccess.__init__(self, path, filename, fileformat, deps, arch)
+            deps: List[str] = []) -> None:
+        AppAccess.__init__(self, path, filename, fileformat, deps)
         self._x86d: Optional[X86Dictionary] = None
         self._functions: Dict[str, X86Function] = {}
 


### PR DESCRIPTION
If you want to check if it's a specific architecture, just do
`isinstance(app, X86Access)` or whathaveyou.

This has the advantage of telling the type system the type
you're looking at -- if you do that, you can do app.x86dictionary
without having to assert that it's an X86Access or cast to x86Access
or something