### PR TITLE
Allow choosing a different format when comparing cfgs

### DIFF
--- a/chb/cmdline/chkx
+++ b/chb/cmdline/chkx
@@ -1069,7 +1069,7 @@ def parse() -> argparse.Namespace:
         "xname2", help="name of second (patched) executable (assumed analyzed)")
     relationalcomparecfgs.add_argument(
         "outputfilename",
-        help="pdf/dot output filename (without extension)")
+        help="output filename (without extension)")
     relationalcomparecfgs.add_argument(
         "--show_calls",
         action="store_true",
@@ -1080,6 +1080,11 @@ def parse() -> argparse.Namespace:
         help="show predicates on the edges of the cfg")
     relationalcomparecfgs.add_argument(
         "--usermapping", help="name of json file with initial function mapping")
+    relationalcomparecfgs.add_argument(
+        "--format",
+        choices=["pdf", "png"],
+        default="pdf",
+        help="format for the generated file")
     relationalcomparecfgs.set_defaults(func=R.relational_compare_cfgs_cmd)
 
     # --- relational compare invariants --

--- a/chb/cmdline/relationalcmds.py
+++ b/chb/cmdline/relationalcmds.py
@@ -426,6 +426,7 @@ def relational_compare_cfgs_cmd(args: argparse.Namespace) -> NoReturn:
     showcalls: bool = args.show_calls
     showpredicates: bool = args.show_predicates
     outputfilename: str = args.outputfilename
+    fileformat: str = args.format
 
     print("Visual comparison of the cfgs for " + xname1 + " and " + xname2)
 
@@ -496,6 +497,7 @@ def relational_compare_cfgs_cmd(args: argparse.Namespace) -> NoReturn:
         app1.path,
         "cfg_comparison",
         outputfilename,
+        fileformat,
         [dotcfg.build() for dotcfg in dotgraphs])
 
     print(relational_header(xname1, xname2, "control-flow-graph comparison"))

--- a/chb/util/dotutil.py
+++ b/chb/util/dotutil.py
@@ -66,6 +66,7 @@ def print_dot_subgraphs(
         path: str,
         gname: str,
         filename: str,
+        fileformat: str,
         subgraphs: List["DotGraph"]) -> str:
     if len(subgraphs) == 0:
         print("No subgraphs supplied")
@@ -89,13 +90,13 @@ def print_dot_subgraphs(
     dotgraph = "\n".join(lines)
 
     dotfilename = filename + ".dot"
-    pdffilename = filename + ".pdf"
+    outputfilename = filename + ".%s" % fileformat
 
     with open(dotfilename, "w") as fp:
         fp.write(dotgraph)
 
-    # convert dot file to pdf
-    cmd = ["dot", "-Tpdf", "-o", pdffilename, dotfilename]
+    # convert dot file to the desired format
+    cmd = ["dot", "-T%s" % fileformat, "-o", outputfilename, dotfilename]
     try:
         subprocess.call(cmd, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
@@ -103,7 +104,7 @@ def print_dot_subgraphs(
         print(e.output)
         print(e.args)
         exit(1)
-    return pdffilename
+    return outputfilename
 
 
 def save_dot(path: str, filename: str, g: "DotGraph") -> None:


### PR DESCRIPTION
I don't know how to display a pdf file within the binary ninja UI, but for a png file I can create a simple html and they have a way to display that.

This adds an extra command line argument to relational compare cfgs called --format. for now I only let the user choose pdf and png, but I could extend it to all the formats allowed by dot if we wanted to. The default continues to be pdf so nothing should need to change on all the existing users. I tested both explicitly asking for pdf and png and also the default and everything worked