### PR TITLE
Avoid unnecessarily casting promoted-type shifts

### DIFF
--- a/chb/ast/AbstractSyntaxTree.py
+++ b/chb/ast/AbstractSyntaxTree.py
@@ -1179,6 +1179,11 @@ class AbstractSyntaxTree:
         if same_signedness and not force_cast:
            return e # No cast needed
 
+        if not same_signedness and t.ikind.startswith("iu") and not force_cast:
+            if t.ikind.endswith("char") or t.ikind.endswith("short"):
+                # unsigned char/short promote to signed int!
+                return e
+
         # Helpers to get a signed/unsigned version of a type
         def withsign(ikind):
           if ikind.endswith("char"):


### PR DESCRIPTION
An unsigned short is shifted with an arithmetic shift, rather than a logical shift, because unsigned short promotes to signed int.

Credit to Ricardo Baratto for finding this bug.