### PR TITLE
Add ASTDeserializer method to read back return sequences

### DIFF
--- a/chb/ast/ASTApplicationInterface.py
+++ b/chb/ast/ASTApplicationInterface.py
@@ -28,7 +28,7 @@
 
 from datetime import datetime
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from chb.ast.AbstractSyntaxTree import AbstractSyntaxTree
 from chb.ast.ASTCodeFragments import ASTCodeFragments
@@ -49,10 +49,14 @@ class ASTApplicationInterface:
 
     def __init__(
             self,
-            support: CustomASTSupport = CustomASTSupport()) -> None:
+            support: CustomASTSupport = CustomASTSupport(),
+            codefragments: Optional[ASTCodeFragments] = None) -> None:
         self._support = support
         self._globalsymboltable = ASTGlobalSymbolTable()
-        self._codefragments = ASTCodeFragments()
+        if codefragments:
+            self._codefragments = codefragments
+        else:
+            self._codefragments = ASTCodeFragments()
         self._fnsdata: List[Dict[str, Any]] = []
 
     @property

--- a/chb/ast/ASTCodeFragments.py
+++ b/chb/ast/ASTCodeFragments.py
@@ -75,11 +75,19 @@ class ASTCodeFragments:
             self._codefragments[index] = ASTCodeFragment(hexstring, assembly)
             return index
 
+    def is_valid_index(self, index: int) -> bool:
+        return index in self.codefragments
+
     def serialize(self) -> Dict[str, Any]:
         result: Dict[str, Any] = {}
         for (index, frag) in sorted(self.codefragments.items()):
             result[str(index)] = frag.serialize()
         return result
+
+    def deserialize(self, serialization: Dict[str, Any]) -> None:
+        for (index, fragment) in serialization.items():
+            self._codefragments[int(index)] = ASTCodeFragment(fragment["hex"],
+                                                              fragment["assembly"])
 
     def __str__(self) -> str:
         lines: List[str] = []

--- a/chb/ast/ASTDeserializer.py
+++ b/chb/ast/ASTDeserializer.py
@@ -31,6 +31,8 @@ from typing import Any, cast, Dict, List, NewType, Optional, Tuple, Union
 from chb.ast.AbstractSyntaxTree import AbstractSyntaxTree, nooffset, voidtype
 import chb.ast.ASTNode as AST
 from chb.ast.ASTSymbolTable import ASTLocalSymbolTable, ASTGlobalSymbolTable
+from chb.ast.ASTReturnSequences import ASTReturnSequences
+from chb.ast.ASTCodeFragments import ASTCodeFragments
 
 
 ASTSpanRecord = NewType(
@@ -634,3 +636,20 @@ class ASTDeserializer:
                 mk_node(r)
 
         return nodes
+
+    def return_sequences_for(self, addr: str) -> ASTReturnSequences:
+        fdata = None
+        for _fdata in self.serialization["functions"]:
+            if addr == _fdata["va"]:
+                fdata = _fdata
+                break
+        if fdata is None:
+            raise ValueError("Function %s not found in serialization" % addr)
+
+        code_fragments = ASTCodeFragments()
+        code_fragments.deserialize(self.serialization["codefragments"])
+
+        return_sequences = ASTReturnSequences(code_fragments)
+        return_sequences.deserialize(fdata["return-sequences"])
+
+        return return_sequences

--- a/chb/ast/ASTReturnSequences.py
+++ b/chb/ast/ASTReturnSequences.py
@@ -68,8 +68,16 @@ class ASTReturnSequences:
             result[address] = str(index)
         return result
 
+    def deserialize(self, serialization: Dict[str, str]) -> None:
+        for (addr, str_index) in serialization.items():
+            index = int(str_index)
+            if not self.codefragments.is_valid_index(index):
+                raise Exception("Index %s not found in codefragments" % index)
+
+            self.addressmap[addr] = index
+
     def __str__(self) -> str:
         lines: List[str] = []
-        for (address, index) in sorted(self.addressmap):
+        for (address, index) in sorted(self.addressmap.items()):
             lines.append(address + ": " + str(self.get_return_sequence(address)))
         return "\n".join(lines)


### PR DESCRIPTION
This adds a method to ASTDeserializer which can build an ASTReturnSequences object. We use this so Binary Ninja can add the return sequences computed by CodeHawk to its lifting output so patching can succeed.

Along the way I also fixed a minor typo in the `__str__` method that was making mypy complain.