### PR TITLE
Account for possibly-empty defuses in ARMBranch.py

### DIFF
--- a/chb/arm/opcodes/ARMBranch.py
+++ b/chb/arm/opcodes/ARMBranch.py
@@ -243,7 +243,7 @@ class ARMBranch(ARMOpcode):
                     hl_lhs = astree.mk_lval(astreturnvar, nooffset)
 
         else:
-            if tgt_returntype.is_void or defuses[0] is None:
+            if tgt_returntype.is_void or not defuses or defuses[0] is None:
                 hl_lhs = None
             else:
                 if len(xdata.vars) > 0:


### PR DESCRIPTION
Some optimized binaries will have an empty `defuses` list and would crash on the unchecked `defuses[0]` access.