### PR TITLE
Fix a number of bugs in the callgraph generation code

### DIFF
--- a/chb/app/Callgraph.py
+++ b/chb/app/Callgraph.py
@@ -258,7 +258,7 @@ class Callgraph:
             pass
 
     def has_node(self, node: CallgraphNode) -> bool:
-        return node.name in self.nodes
+        return node.name in self.nodes or str(node) in self.nodes
 
     def add_edge(self, src: CallgraphNode, dst: CallgraphNode) -> None:
         self.add_node(src)
@@ -302,10 +302,10 @@ class Callgraph:
         while edgesadded:
             edgesadded = False
             for (src, dsts) in self.edges.items():
+                if not result.has_node(self.nodes[src]):
+                    continue
                 for dst in dsts:
-                    if (
-                            result.has_node(self.nodes[src])
-                            and not result.has_edge(src, dst)):
+                    if not result.has_edge(src, dst):
                         result.add_edge(self.nodes[src], self.nodes[dst])
                         edgesadded = True
         return result

--- a/chb/cmdline/reportcmds.py
+++ b/chb/cmdline/reportcmds.py
@@ -491,7 +491,7 @@ def report_calls(
                     if fname is not None:
                         function_names[faddr] = fname
                     if callgraph is not None:
-                        tgtpath = callgraph.constrain_sinks([faddr])
+                        tgtpath = callgraph.constrain_sinks([tgtfunction.name])
                     callrec = CallRecord(
                         faddr, instr, tgtfunction, callgraph=tgtpath).to_json_result()
                     if callrec.is_ok:
@@ -517,7 +517,7 @@ def report_calls(
     if callgraph is not None:
         cgcount = len([cs for cs in callsites if len(cs["cgpath"]["edges"]) > 0])
         UC.print_status_update(
-            "Nonempty callgraph path to: "
+            "Nonempty callgraph path from: "
             + str(xcgpathsrc)
             + ": "
             + str(cgcount)


### PR DESCRIPTION
The biggest issue that is fixed is that some nodes use the function name and some use the function address and it gets pretty confusing which one we should be using. this is a bit of a hack in that we just check both, but it feels like always using the same (probably address?) would be best.

This also fixes a bug where we were constraining the sinks by the source and not the destination, and a typo in the status message.

Finally, this streamlines the code a bit so we don't do the same check on every iteration of the subloop that can be done in the outer loop