### PR TITLE
More callgraph fixes

### DIFF
--- a/chb/cmdline/reportcmds.py
+++ b/chb/cmdline/reportcmds.py
@@ -493,7 +493,8 @@ def report_calls(
                     if fname is not None:
                         function_names[faddr] = fname
                     if callgraph is not None:
-                        tgtpath = callgraph.constrain_sinks([tgtfunction.name])
+                        UC.print_status_update("Generating callgraph for callsite at " + str(instr))
+                        tgtpath = callgraph.constrain_sink_edge(src=faddr, dst=tgtfunction.name)
                     callrec = CallRecord(
                         faddr, instr, tgtfunction, callgraph=tgtpath).to_json_result()
                     if callrec.is_ok:

--- a/chb/jsoninterface/JSONCallgraph.py
+++ b/chb/jsoninterface/JSONCallgraph.py
@@ -45,7 +45,7 @@ class JSONCallgraphEdge(JSONObject):
 
     @property
     def tgt(self) -> str:
-        return self.d.get("tgt", self.property_missing("tgt"))
+        return self.d.get("dst", self.property_missing("dst"))
 
     @property
     def type(self) -> Optional[str]:
@@ -80,21 +80,32 @@ class JSONCallgraph(JSONObject):
 
     def __init__(self, d: Dict[str, Any]) -> None:
         JSONObject.__init__(self, d, "callgraph")
+        self._nodes: Optional[List[JSONCallgraphNode]] = None
+        self._edges: Optional[List[JSONCallgraphEdge]] = None
 
     @property
     def nodes(self) -> List[JSONCallgraphNode]:
-        return self.d.get("nodes", [])
+        if self._nodes is None:
+            result: List[JSONCallgraphNode] = []
+            raw_nodes = self.d.get("nodes", [])
+            for raw_node in raw_nodes:
+                result.append(JSONCallgraphNode(raw_node))
+
+            self._nodes = result
+
+        return self._nodes
 
     @property
     def edges(self) -> List[JSONCallgraphEdge]:
-        return self.d.get("edges", [])
+        if self._edges is None:
+            result: List[JSONCallgraphEdge] = []
+            raw_edges = self.d.get("edges", [])
+            for raw_node in raw_edges:
+                result.append(JSONCallgraphEdge(raw_node))
+
+            self._edges = result
+
+        return self._edges
 
     def accept(self, visitor: "JSONObjectVisitor") -> None:
         visitor.visit_callgraph(self)
-
-
-                          
-
-    
-                        
-

--- a/chb/jsoninterface/JSONCallsiteRecords.py
+++ b/chb/jsoninterface/JSONCallsiteRecords.py
@@ -27,8 +27,8 @@
 
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 
-
 from chb.jsoninterface.JSONObject import JSONObject
+from chb.jsoninterface.JSONCallgraph import JSONCallgraph
 
 if TYPE_CHECKING:
     from chb.jsoninterface.JSONObjectVisitor import JSONObjectVisitor
@@ -112,6 +112,7 @@ class JSONCallsiteRecord(JSONObject):
     def __init__(self, d: Dict[str, Any]) -> None:
         JSONObject.__init__(self, d, "callsiterecord")
         self._arguments: Optional[List[JSONCallsiteArgument]] = None
+        self._cgpath: Optional[JSONCallgraph] = None
 
     @property
     def faddr(self) -> str:
@@ -129,6 +130,17 @@ class JSONCallsiteRecord(JSONObject):
                 result.append(JSONCallsiteArgument(arg))
             self._arguments = result
         return self._arguments
+
+    @property
+    def cgpath(self) -> Optional[JSONCallgraph]:
+        if self._cgpath is None:
+            cgpath = self.d.get("cgpath")
+            if cgpath is None:
+                return None
+
+            self._cgpath = JSONCallgraph(cgpath)
+
+        return self._cgpath
 
     def column_count(self) -> int:
         result: int = 0
@@ -170,7 +182,8 @@ class JSONCallsiteRecords(JSONObject):
                 else:
                     result[fnaddr] = fnname
             self._function_names = result
-        return result
+
+        return self._function_names
 
     @property
     def cgpath_src(self) -> Optional[str]:
@@ -207,6 +220,3 @@ class JSONCallsiteRecords(JSONObject):
 
     def accept(self, visitor: "JSONObjectVisitor") -> None:
         visitor.visit_callsite_records(self)
-    
-
-                              


### PR DESCRIPTION
Two fixes:
- Expose the callgraph for callsites through the JSON API
- A hackish fix to get Callgraph functionality working. Here's the copy/paste from my novel-like commit message:

The core issue is that some nodes use the function name as their
identifier and some use the function address. But if we also have the
function name for the latter, and that is what the user requests,
things get really confusing.

This adds the notion of nodes having multiple IDs and makes the
code use that (although i'm not 100% sure i covered all the cases).
One big gaping hole in this fix are edges. They're stored using
only the strings, so checking for edge existence is non-trivial
as you need to see if any of the node ids for each node matches
the source or destination.

This also fixes an issue where user functions are first seen as
`so stubs` and then we see the actual function. Before we would
store both as nodes, one of them using the function name (which
is all that stubs have) and another one using the function's address
as its identifier. Once I switched things (as described above) this
bug surfaced. The fix is to check for this particular case, and
replace the existing stub node with the user function node.
