### PR TITLE
Syntactic check: md5 comparison

### DIFF
--- a/chb/app/AppAccess.py
+++ b/chb/app/AppAccess.py
@@ -261,6 +261,13 @@ class AppAccess(ABC, Generic[HeaderTy]):
         """Return a list of all application function addresses."""
         return self.appresultdata.function_addresses()
 
+    @property
+    def function_md5s(self) -> Dict[str, str]:
+        """Return a mapping from function address to md5 for all functions.
+
+        Note: not all of these functions may have been analyzed."""
+        return self.appresultdata.function_md5s
+
     def has_function(self, faddr: str) -> bool:
         return faddr in self.appfunction_addrs
 

--- a/chb/app/CHVersion.py
+++ b/chb/app/CHVersion.py
@@ -1,1 +1,1 @@
-chbversion: str = "0.3.0-20240229"
+chbversion: str = "0.3.0-20240301"

--- a/chb/cmdline/AnalysisManager.py
+++ b/chb/cmdline/AnalysisManager.py
@@ -266,6 +266,7 @@ class AnalysisManager(object):
             collectdiagnostics: bool = False,
             ignore_stable: bool = False,
             save_asm: bool = False,
+            construct_all_functions: bool = False,
             mem: bool = False,
             timeout: Optional[int] = None,
             preamble_cutoff: int = 12) -> int:
@@ -279,6 +280,7 @@ class AnalysisManager(object):
             mem=mem,
             timeout=timeout,
             verbose=verbose,
+            construct_all_functions=construct_all_functions,
             collectdiagnostics=collectdiagnostics,
             preamble_cutoff=preamble_cutoff)
         return result
@@ -412,6 +414,7 @@ class AnalysisManager(object):
             mem: bool = False,
             timeout: Optional[int] = None,
             verbose: bool = False,
+            construct_all_functions: bool = False,
             collectdiagnostics: bool = False,
             preamble_cutoff: int = 12) -> int:
         cwd = os.getcwd()
@@ -453,6 +456,8 @@ class AnalysisManager(object):
             cmd.append("-diagnostics")
         if asm:
             cmd.append("-save_asm")
+        if construct_all_functions:
+            cmd.append("-construct_all_functions")
         if self.show_function_timing:
             cmd.append("-show_function_timing")
         if self.gc_compact > 0:

--- a/chb/cmdline/astcmds.py
+++ b/chb/cmdline/astcmds.py
@@ -121,6 +121,7 @@ def library_call_targets(app: AppAccess, faddrs: List[str]) -> List[str]:
 
     result: Set[str] = set([])
     for faddr in faddrs:
+        print("DEBUG:faddr: " + faddr)
         if app.has_function(faddr):
             f = app.function(faddr)
             fcallees = f.call_instructions()

--- a/chb/cmdline/chkx
+++ b/chb/cmdline/chkx
@@ -378,6 +378,10 @@ def parse() -> argparse.Namespace:
         choices=["yes", "no"],
         help='save asm listing in analysis directory')
     analyzecmd.add_argument(
+        "--construct_all_functions",
+        action="store_true",
+        help="construct all functions even if not all functions are analyzed")
+    analyzecmd.add_argument(
         "--collect_diagnostics",
         action="store_true",
         help="save diagnostics in a separate diagnostics log file")
@@ -1161,6 +1165,10 @@ def parse() -> argparse.Namespace:
         nargs="*",
         default=[],
         help="names of c header files with summaries/data structures")
+    relationalprepare.add_argument(
+        "--construct_all_functions",
+        action="store_true",
+        help=("construct all functions, even if not all functions are analyzed"))
     relationalprepare.add_argument(
         "--ssa",
         action="store_true",

--- a/chb/cmdline/commandutil.py
+++ b/chb/cmdline/commandutil.py
@@ -390,6 +390,7 @@ def analyzecmd(args: argparse.Namespace) -> NoReturn:
     fns_exclude: List[str] = args.fns_exclude  # function hex addresses
     fns_include: List[str] = args.fns_include  # function hex addresses
     gc_compact: int = args.gc_compact
+    construct_all_functions: bool = args.construct_all_functions
     show_function_timing: bool = args.show_function_timing
     lineq_instr_cutoff: int = args.lineq_instr_cutoff
     lineq_block_cutoff: int = args.lineq_block_cutoff
@@ -513,6 +514,7 @@ def analyzecmd(args: argparse.Namespace) -> NoReturn:
                 analysisrepeats=analysisrepeats,
                 iterations=iterations,
                 verbose=verbose,
+                construct_all_functions=construct_all_functions,
                 collectdiagnostics=collectdiagnostics,
                 preamble_cutoff=preamble_cutoff)
         except subprocess.CalledProcessError as e:

--- a/chb/cmdline/relationalcmds.py
+++ b/chb/cmdline/relationalcmds.py
@@ -4,7 +4,7 @@
 # ------------------------------------------------------------------------------
 # The MIT License (MIT)
 #
-# Copyright (c) 2021-2023  Aarno Labs, LLC
+# Copyright (c) 2021-2024  Aarno Labs, LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -146,6 +146,7 @@ def relational_prepare_command(args: argparse.Namespace) -> NoReturn:
     xpatchresults: Optional[str] = args.patch_results_file
     xprint: bool = not args.json
     xssa: bool = args.ssa
+    xconstruct_all_functions: bool = args.construct_all_functions
 
     try:
         (path1, xfile1) = UC.get_path_filename(xname1)
@@ -271,7 +272,10 @@ def relational_prepare_command(args: argparse.Namespace) -> NoReturn:
         thumb=True)
 
     try:
-        am.analyze(iterations=10, save_asm=xsave_asm)
+        am.analyze(
+            iterations=10,
+            save_asm=xsave_asm,
+            construct_all_functions=xconstruct_all_functions)
     except subprocess.CalledProcessError as e:
         print(e.output)
         print(e.args)

--- a/chb/jsoninterface/JSONAppComparison.py
+++ b/chb/jsoninterface/JSONAppComparison.py
@@ -4,7 +4,7 @@
 # ------------------------------------------------------------------------------
 # The MIT License (MIT)
 #
-# Copyright (c) 2023  Aarno Labs LLC
+# Copyright (c) 2023-2024  Aarno Labs LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -95,6 +95,45 @@ class JSONFunctionAdded(JSONObject):
         visitor.visit_function_added(self)
 
 
+class JSONFunctionMD5(JSONObject):
+    """Function address with md5 of syntactic assembly representation string."""
+
+    def __init__(self, d: Dict[str, str]) -> None:
+        JSONObject.__init__(self, d, "functionmd5")
+
+    @property
+    def faddr(self) -> str:
+        return self.d.get("faddr", self.property_missing("faddr"))
+
+    @property
+    def md5(self) -> str:
+        return self.d.get("md5", self.property_missing("md5"))
+
+    def accept(self, visitor: "JSONObjectVisitor") -> None:
+        visitor.visit_function_md5(self)
+
+
+class JSONAppMD5Comparison(JSONObject):
+    """Raw listing of the functions constructed in the two binaries.
+
+    This object presents two lists of function, md5 pairs that lets a client tool
+    confirm which functions have syntactically changed in the binary."""
+
+    def __init__(self, d: Dict[str, Any]) -> None:
+        JSONObject.__init__(self, d, "functions-constructed")
+
+    @property
+    def file1(self) -> List[JSONFunctionMD5]:
+        return self.d.get("file1", self.property_missing("file1"))
+
+    @property
+    def file2(self) -> List[JSONFunctionMD5]:
+        return self.d.get("file2", self.property_missing("file2"))
+
+    def accept(self, visitor: "JSONObjectVisitor") -> None:
+        visitor.visit_app_md5_comparison(self)
+
+
 class JSONAppComparison(JSONObject):
 
     def __init__(self, d: Dict[str, Any]) -> None:
@@ -109,6 +148,7 @@ class JSONAppComparison(JSONObject):
         self._globalvarscompared: Optional[List[str]] = None
         self._globalvarschanged: Optional[List[JSONGlobalVarComparison]] = None
         self._binarycomparison: Optional[JSONBinaryComparison] = None
+        self._appmd5comparison: Optional[JSONAppMD5Comparison] = None
 
     @property
     def file1(self) -> str:

--- a/chb/jsoninterface/JSONCHBSchemas.py
+++ b/chb/jsoninterface/JSONCHBSchemas.py
@@ -4,7 +4,7 @@
 # ------------------------------------------------------------------------------
 # The MIT License (MIT)
 #
-# Copyright (c) 2023  Aarno Labs LLC
+# Copyright (c) 2023-2024  Aarno Labs LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1257,6 +1257,30 @@ binarycomparison = {
 }
 
 
+appmd5comparison = {
+    "name": "appmd5comparison",
+    "title": "syntactic check of functions changed",
+    "description": (
+        "raw listing of function address/md5 pairs to enable syntactic "
+        + "comparison"),
+    "type": "object",
+    "properties": {
+        "file1": {
+            "type": "array",
+            "description": "function address / md5 pairs for file1",
+            "items": strtupletype(
+                "faddr", "md5", "md5 of syntactic assembly function string")
+            },
+        "file2": {
+            "type": "array",
+            "description": "function address / md5 pairs for file2",
+            "items": strtupletype(
+                "faddr", "md5", "md5 of syntactic assembly function string")
+            }
+        }
+    }
+
+
 appcomparison = {
     "name": "appcomparison",
     "title": "application comparison",
@@ -1303,7 +1327,8 @@ appcomparison = {
             "description": ("list of changes in global variables"),
             "items": refdef("globalvarcomparison")
         },
-        "binary-comparison": refdef("binarycomparison")
+        "binary-comparison": refdef("binarycomparison"),
+        "app-md5-comparison": refdef("appmd5comparison")
     }
 }
 

--- a/chb/jsoninterface/JSONObjectNOPVisitor.py
+++ b/chb/jsoninterface/JSONObjectNOPVisitor.py
@@ -4,7 +4,7 @@
 # ------------------------------------------------------------------------------
 # The MIT License (MIT)
 #
-# Copyright (c) 2023  Aarno Labs LLC
+# Copyright (c) 2023-2024  Aarno Labs LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -44,6 +44,9 @@ class JSONObjectNOPVisitor(JSONObjectVisitor):
         pass
 
     def visit_app_comparison(self, obj: AppC.JSONAppComparison) -> None:
+        pass
+
+    def visit_app_md5_comparison(self, obj: AppC.JSONAppMD5Comparison) -> None:
         pass
 
     def visit_assembly_block(self, obj: JSONAssemblyBlock) -> None:
@@ -90,6 +93,10 @@ class JSONObjectNOPVisitor(JSONObjectVisitor):
 
     def visit_function_comparison(
             self, obj: FunC.JSONFunctionComparison) -> None:
+        pass
+
+    def visit_function_md5(
+            self, obj: AppC.JSONFunctionMD5) -> None:
         pass
 
     def visit_function_semantic_comparison(

--- a/chb/jsoninterface/JSONObjectVisitor.py
+++ b/chb/jsoninterface/JSONObjectVisitor.py
@@ -4,7 +4,7 @@
 # ------------------------------------------------------------------------------
 # The MIT License (MIT)
 #
-# Copyright (c) 2023  Aarno Labs LLC
+# Copyright (c) 2023-2024  Aarno Labs LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -45,6 +45,9 @@ class JSONObjectVisitor(ABC):
         pass
 
     def visit_app_comparison(self, obj: AppC.JSONAppComparison) -> None:
+        ...
+
+    def visit_app_md5_comparison(self, obj: AppC.JSONAppMD5Comparison) -> None:
         ...
 
     def visit_assembly_block(self, obj: JSONAssemblyBlock) -> None:
@@ -117,6 +120,10 @@ class JSONObjectVisitor(ABC):
 
     def visit_function_comparison(
             self, obj: FunC.JSONFunctionComparison) -> None:
+        ...
+
+    def visit_function_md5(
+            self, obj: AppC.JSONFunctionMD5) -> None:
         ...
 
     def visit_function_semantic_comparison(

--- a/chb/jsoninterface/JSONSchemaRegistry.py
+++ b/chb/jsoninterface/JSONSchemaRegistry.py
@@ -4,7 +4,7 @@
 # ------------------------------------------------------------------------------
 # The MIT License (MIT)
 #
-# Copyright (c) 2023  Aarno Labs LLC
+# Copyright (c) 2023-2024  Aarno Labs LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -100,6 +100,7 @@ json_schema_registry: JSONSchemaRegistry = JSONSchemaRegistry()
 
 chb_schemas: List[Dict[str, Any]] = [
     S.appcomparison,
+    S.appmd5comparison,
     S.auxvariable,
     S.assemblyblock,
     S.assemblyfunction,

--- a/chb/relational/RelationalAnalysis.py
+++ b/chb/relational/RelationalAnalysis.py
@@ -4,7 +4,7 @@
 # ------------------------------------------------------------------------------
 # The MIT License (MIT)
 #
-# Copyright (c) 2021-2023 Aarno Labs, LLC
+# Copyright (c) 2021-2024 Aarno Labs, LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -105,6 +105,14 @@ class RelationalAnalysis:
     @property
     def faddrs2(self) -> Sequence[str]:
         return self._faddrs2
+
+    @property
+    def md5s1(self) -> Dict[str, str]:
+        return self.app1.function_md5s
+
+    @property
+    def md5s2(self) -> Dict[str, str]:
+        return self.app2.function_md5s
 
     @property
     def fncount1(self) -> int:
@@ -219,6 +227,18 @@ class RelationalAnalysis:
                 result.append(faddr)
         return result
 
+    def md5_comparison_to_json_result(self) -> JSONResult:
+        content: Dict[str, Any] = {}
+        content["file1"] = []
+        content["file2"] = []
+        for (faddr, md5) in self.md5s1.items():
+            md5r1: Dict[str, str] = {"faddr": faddr, "md5": md5}
+            content["file1"].append(md5r1)
+        for (faddr, md5) in self.md5s2.items():
+            md5r2: Dict[str, str] = {"faddr": faddr, "md5": md5}
+            content["file2"].append(md5r2)
+        return JSONResult("appmd5comparison", content, "ok")
+
     def to_json_result(self) -> JSONResult:
         content: Dict[str, Any] = {}
         content["file1"] = {}
@@ -236,6 +256,7 @@ class RelationalAnalysis:
                 content["functions-changed"].append(fra.content)
             else:
                 return JSONResult("appcomparison", {}, "fail", fra.reason)
+        content["app-md5-comparison"] = self.md5_comparison_to_json_result().content
         return JSONResult("appcomparison", content, "ok")
 
     def callgraph_summary_result(self) -> JSONResult:


### PR DESCRIPTION
Add a raw listing of assembly function md5's to the app-comparison relational analysis for all assembly functions that were constructed, including those that were not analyzed.

By default only the functions that are analyzed are constructed (by the disassembler). To force all functions to be constructed, add the option --construct_all_functions to both the analyze command and the relational-prepare command.