### PR TITLE
Lifting

### DIFF
--- a/chb/app/AppResultData.py
+++ b/chb/app/AppResultData.py
@@ -65,10 +65,17 @@ class AppResultData:
                 xfa = f.get("fa")
                 xmd5 = f.get("md5")
                 xrf = f.get("rf")
-                if xfa is not None and xmd5 is not None and xrf is not None:
-                    if xrf == "Y":
+                if xfa is not None and xmd5 is not None:
+                    if xrf is None:
+                        # temporary fix until all architectures have the
+                        # xrf attributes
                         self._functions_analyzed.append(xfa)
-                    self._function_md5s[xfa] = xmd5
+                        self._function_md5s[xfa] = xmd5
+                    else:
+                        if xrf == "Y":
+                            self._functions_analyzed.append(xfa)
+                        self._function_md5s[xfa] = xmd5
+
 
     def function_addresses(self) -> List[str]:
         return self.functions_analyzed

--- a/chb/app/CHVersion.py
+++ b/chb/app/CHVersion.py
@@ -1,1 +1,1 @@
-chbversion: str = "0.3.0-20240301"
+chbversion: str = "0.3.0-20240301A"

--- a/chb/cmdline/astcmds.py
+++ b/chb/cmdline/astcmds.py
@@ -4,7 +4,7 @@
 # ------------------------------------------------------------------------------
 # The MIT License (MIT)
 #
-# Copyright (c) 2022-2023  Aarno Labs, LLC
+# Copyright (c) 2022-2024  Aarno Labs, LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -121,7 +121,6 @@ def library_call_targets(app: AppAccess, faddrs: List[str]) -> List[str]:
 
     result: Set[str] = set([])
     for faddr in faddrs:
-        print("DEBUG:faddr: " + faddr)
         if app.has_function(faddr):
             f = app.function(faddr)
             fcallees = f.call_instructions()

--- a/chb/invariants/InvariantFact.py
+++ b/chb/invariants/InvariantFact.py
@@ -6,7 +6,7 @@
 #
 # Copyright (c) 2016-2020 Kestrel Technology LLC
 # Copyright (c) 2020      Henny Sipma
-# Copyright (c) 2021-2023 Aarno Labs LLC
+# Copyright (c) 2021-2024 Aarno Labs LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/chb/invariants/VAssemblyVariable.py
+++ b/chb/invariants/VAssemblyVariable.py
@@ -6,7 +6,7 @@
 #
 # Copyright (c) 2016-2020 Kestrel Technology LLC
 # Copyright (c) 2020      Henny Sipma
-# Copyright (c) 2021-2023 Aarno Labs LLC
+# Copyright (c) 2021-2024 Aarno Labs LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -133,6 +133,10 @@ class VAssemblyVariable(FnVarDictionaryRecord):
 
     @property
     def is_bridge_variable(self) -> bool:
+        return False
+
+    @property
+    def is_frozen_test_value(self) -> bool:
         return False
 
     @property
@@ -430,6 +434,10 @@ class VAuxiliaryVariable(VAssemblyVariable):
     @property
     def is_bridge_variable(self) -> bool:
         return self.auxvar.is_bridge_variable
+
+    @property
+    def is_frozen_test_value(self) -> bool:
+        return self.auxvar.is_frozen_test_value
 
     @property
     def is_structured_value(self) -> bool:

--- a/chb/invariants/VConstantValueVariable.py
+++ b/chb/invariants/VConstantValueVariable.py
@@ -6,7 +6,7 @@
 #
 # Copyright (c) 2016-2020 Kestrel Technology LLC
 # Copyright (c) 2020      Henny Sipma
-# Copyright (c) 2021-2023 Aarno Labs LLC
+# Copyright (c) 2021-2024 Aarno Labs LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/chb/invariants/XVariable.py
+++ b/chb/invariants/XVariable.py
@@ -6,7 +6,7 @@
 #
 # Copyright (c) 2016-2020 Kestrel Technology LLC
 # Copyright (c) 2020-2021 Henny Sipma
-# Copyright (c) 2021-2023 Aarno Labs LLC
+# Copyright (c) 2021-2024 Aarno Labs LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -85,6 +85,14 @@ class XVariable(FnXprDictionaryRecord):
     @property
     def is_register_variable(self) -> bool:
         return self.has_denotation() and self.denotation.is_register_variable
+
+    @property
+    def is_bridge_variable(self) -> bool:
+        return self.has_denotation() and self.denotation.is_bridge_variable
+
+    @property
+    def is_frozen_test_value(self) -> bool:
+        return self.has_denotation() and self.denotation.is_frozen_test_value
 
     @property
     def is_initial_register_value(self) -> bool:


### PR DESCRIPTION
Removes locations that are part of functions inlined by the analysis from the available expressions in the PIR.
Removes test-value variables from the available expressions in the PIR.