### PR TITLE
Create two views of the CFG

### DIFF
--- a/chb/app/CHVersion.py
+++ b/chb/app/CHVersion.py
@@ -1,1 +1,1 @@
-chbversion: str = "0.3.0-20240401"
+chbversion: str = "0.3.0-20240402"

--- a/chb/app/CfgBlock.py
+++ b/chb/app/CfgBlock.py
@@ -4,7 +4,7 @@
 # ------------------------------------------------------------------------------
 # The MIT License (MIT)
 #
-# Copyright (c) 2021-2023  Aarno Labs LLC
+# Copyright (c) 2021-2024  Aarno Labs LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/chb/app/Function.py
+++ b/chb/app/Function.py
@@ -4,7 +4,7 @@
 # ------------------------------------------------------------------------------
 # The MIT License (MIT)
 #
-# Copyright (c) 2021-2023  Aarno Labs LLC
+# Copyright (c) 2021-2024  Aarno Labs LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/chb/app/TrampolineInfo.py
+++ b/chb/app/TrampolineInfo.py
@@ -100,7 +100,7 @@ class TrampolineInfo:
         Note that this address is outside of the trampoline itself.
         In most cases this address is the same as (one of) the prenodes.
         """
-        
+
         return self.patchevent.logicalva
 
     @property
@@ -120,7 +120,7 @@ class TrampolineInfo:
         for (role, addr) in self.roles.items():
             if role.startswith("payload"):
                 result.append(addr)
-        return result                
+        return result
 
     @property
     def cases(self) -> List[str]:
@@ -140,7 +140,6 @@ class TrampolineInfo:
         lines.append("edges        :")
         for src in self.internal_edges:
             lines.append(
-                "   (" + src + " ==> [" ", ".join(self.internal_edges[src]) + "]")
+                "   ("
+                + src + " ==> [" + ", ".join(self.internal_edges[src]) + "])")
         return "\n".join(lines)
-                     
- 

--- a/chb/cmdline/astcmds.py
+++ b/chb/cmdline/astcmds.py
@@ -35,8 +35,6 @@ from typing import (
 
 from chb.app.AppAccess import AppAccess
 
-from chb.arm.ARMCfg import astmode, patchevents
-
 from chb.ast.AbstractSyntaxTree import AbstractSyntaxTree
 from chb.ast.ASTApplicationInterface import ASTApplicationInterface
 from chb.ast.ASTBasicCTyper import ASTBasicCTyper
@@ -54,7 +52,7 @@ from chb.astinterface.BC2ASTConverter import BC2ASTConverter
 from chb.astinterface.CHBASTSupport import CHBASTSupport
 
 import chb.cmdline.commandutil as UC
-from chb.cmdline.PatchResults import PatchResults
+from chb.cmdline.PatchResults import PatchResults, PatchEvent
 import chb.cmdline.XInfo as XI
 
 from chb.userdata.UserHints import UserHints
@@ -146,8 +144,6 @@ def buildast(args: argparse.Namespace) -> NoReturn:
     showdiagnostics: bool = args.showdiagnostics
     showinfolog: bool = args.showinfolog
 
-    astmode.append("ast")
-
     try:
         (path, xfile) = UC.get_path_filename(xname)
         UF.check_analysis_results(path, xfile)
@@ -162,6 +158,8 @@ def buildast(args: argparse.Namespace) -> NoReturn:
     if xpatchresultsfile is not None:
         with open(xpatchresultsfile, "r") as fp:
             patchresultsdata = json.load(fp)
+
+    patchevents: Dict[str, PatchEvent] = {}
 
     if patchresultsdata is not None:
         patchresults = PatchResults(patchresultsdata)
@@ -286,7 +284,8 @@ def buildast(args: argparse.Namespace) -> NoReturn:
                 showdiagnostics=showdiagnostics,
                 showinfolog=showinfolog)
 
-            astfunction = ASTInterfaceFunction(faddr, fname, f, astinterface)
+            astfunction = ASTInterfaceFunction(
+                faddr, fname, f, astinterface, patchevents=patchevents)
 
             try:
                 asts = astfunction.mk_asts(support)

--- a/chb/cmdline/relationalcmds.py
+++ b/chb/cmdline/relationalcmds.py
@@ -35,12 +35,10 @@ import subprocess
 
 from typing import Any, cast, Dict, List, NoReturn, Optional, Tuple
 
-from chb.arm.ARMCfg import astmode, patchevents
-
 from chb.cmdline.AnalysisManager import AnalysisManager
 import chb.cmdline.commandutil as UC
 import chb.cmdline.jsonresultutil as JU
-from chb.cmdline.PatchResults import PatchResults
+from chb.cmdline.PatchResults import PatchResults, PatchEvent
 from chb.cmdline.XComparison import XComparison
 import chb.cmdline.XInfo as XI
 
@@ -401,8 +399,9 @@ def relational_compare_function_cmd(args: argparse.Namespace) -> NoReturn:
         with open(xpatchresults, "r") as fp:
             patchresultsdata = json.load(fp)
 
+    patchevents: Dict[str, PatchEvent] = {} # start of wrapper -> patch event
+
     if patchresultsdata is not None:
-        astmode.append("ast")
         patchresults = PatchResults(patchresultsdata)
         for event in patchresults.events:
             if event.is_trampoline:
@@ -418,7 +417,11 @@ def relational_compare_function_cmd(args: argparse.Namespace) -> NoReturn:
     app2 = UC.get_app(path2, xfile2, xinfo2)
 
     relanalysis = RelationalAnalysis(
-        app1, app2, faddrs1=addresses, usermapping=usermapping)
+        app1,
+        app2,
+        faddrs1=addresses,
+        usermapping=usermapping,
+        patchevents=patchevents)
 
     print(relational_header(
         xname1,
@@ -458,13 +461,14 @@ def relational_compare_cfgs_cmd(args: argparse.Namespace) -> NoReturn:
         print(str(e.wrap()))
         exit(1)
 
+    patchevents: Dict[str, PatchEvent] = {} # start of wrapper -> patch event
+
     patchresultsdata: Optional[Dict[str, Any]] = None
     if xpatchresults is not None:
         with open(xpatchresults, "r") as fp:
             patchresultsdata = json.load(fp)
 
     if patchresultsdata is not None:
-        astmode.append("ast")
         patchresults = PatchResults(patchresultsdata)
         for event in patchresults.events:
             if event.is_trampoline:
@@ -490,7 +494,8 @@ def relational_compare_cfgs_cmd(args: argparse.Namespace) -> NoReturn:
     app1 = UC.get_app(path1, xfile1, xinfo1)
     app2 = UC.get_app(path2, xfile2, xinfo2)
 
-    relanalysis = RelationalAnalysis(app1, app2, usermapping=usermapping)
+    relanalysis = RelationalAnalysis(
+        app1, app2, usermapping=usermapping, patchevents=patchevents)
 
     functionschanged = relanalysis.functions_changed()
     if len(functionschanged) == 0:

--- a/chb/relational/RelationalAnalysis.py
+++ b/chb/relational/RelationalAnalysis.py
@@ -35,6 +35,7 @@ import chb.util.fileutil as UF
 
 if TYPE_CHECKING:
     from chb.app.AppAccess import AppAccess
+    from chb.cmdline.PatchResults import PatchEvent
 
 
 class RelationalAnalysis:
@@ -72,7 +73,8 @@ class RelationalAnalysis:
             faddrs1: List[str] = [],
             faddrs2: List[str] = [],
             usermapping: Dict[str, str] = {},
-            callees: List[str] = []) -> None:
+            callees: List[str] = [],
+            patchevents: Dict[str, "PatchEvent"] = {}) -> None:
         self._app1 = app1
         self._app2 = app2
         if faddrs1:
@@ -85,6 +87,7 @@ class RelationalAnalysis:
             self._faddrs2 = sorted(app2.appfunction_addrs)
         self._usermapping = usermapping
         self._callees = callees
+        self._patchevents = patchevents
         self._functionmapping: Dict[str, str] = {}  # potentially partial map
         self._functionanalyses: Dict[str, FunctionRelationalAnalysis] = {}
         self._functionnames: Dict[str, str] = {}
@@ -105,6 +108,10 @@ class RelationalAnalysis:
     @property
     def faddrs2(self) -> Sequence[str]:
         return self._faddrs2
+
+    @property
+    def patchevents(self) -> Dict[str, "PatchEvent"]:
+        return self._patchevents
 
     @property
     def md5s1(self) -> Dict[str, str]:
@@ -151,7 +158,7 @@ class RelationalAnalysis:
                     fn1 = self.app1.function(faddr1)
                     fn2 = self.app2.function(faddr2)
                     self._functionanalyses[faddr1] = FunctionRelationalAnalysis(
-                        self.app1, fn1, self.app2, fn2)
+                        self.app1, fn1, self.app2, fn2, self.patchevents)
         return self._functionanalyses
 
     def function_analysis(self, faddr: str) -> FunctionRelationalAnalysis:


### PR DESCRIPTION
The relational analysis now maintains two separate views of the CFG: one is the original, flat view, in the other the basic blocks that are part of the trampoline are collapsed into a single, composite TrampolineBlock that provides accessors to the constituting blocks according to their roles in the trampoline.