### PR TITLE
A couple of cfg diff fixes

### DIFF
--- a/chb/arm/ARMCfg.py
+++ b/chb/arm/ARMCfg.py
@@ -227,17 +227,17 @@ class ARMCfg(Cfg):
                 addr = inlinemap[payload_baseaddrs[0]][0]
                 trinfo.add_role("payload", addr)
                 trampolineblocks[addr] = baddr
-
-            for (i, pba) in enumerate(
-                    sorted(payload_baseaddrs, key= lambda p: int(p, 16))):
-                if len(inlinemap[pba]) == 1:
-                    addr = inlinemap[pba][0]
-                    trinfo.add_role("payload-" + str(i), addr)
-                    trampolineblocks[addr] = baddr
-                else:
-                    for (j, fa) in enumerate(inlinemap[pba]):
-                        trinfo.add_role("payload-" + str(i) + "-" + str(j), fa)
-                        trampolineblocks[fa] = baddr
+            else:
+                for (i, pba) in enumerate(
+                        sorted(payload_baseaddrs, key= lambda p: int(p, 16))):
+                    if len(inlinemap[pba]) == 1:
+                        addr = inlinemap[pba][0]
+                        trinfo.add_role("payload-" + str(i), addr)
+                        trampolineblocks[addr] = baddr
+                    else:
+                        for (j, fa) in enumerate(inlinemap[pba]):
+                            trinfo.add_role("payload-" + str(i) + "-" + str(j), fa)
+                            trampolineblocks[fa] = baddr
 
             if "fallthrough" in canonical_cases:
                 caseaddr = patchevent.label_address(baddr, "case_fallthrough")

--- a/chb/cmdline/jsonresultutil.py
+++ b/chb/cmdline/jsonresultutil.py
@@ -255,4 +255,5 @@ def function_cfg_comparison_to_json_result(
         blockschanged.extend(fblockschanged)
         content["blocks-changed"] = blockschanged
     content["changes"] = fra.changes
+    content["matches"] = fra.matches
     return JSONResult(schema, content, "ok")


### PR DESCRIPTION
This PR has two commits that do some minor fixes to CH's CFG diff code:
- if there's only one payload block in the trampoline, don't generate two separate payload roles. Without this change we get two roles for the same block, `payload` and `payload-0`. Now we just get `payload`.
- include the matches as well as the changes for the function relational analysis. This is mostly for completeness sake.