### PR TITLE
Use the full context address to reference blocks in cfg diff json output

### DIFF
--- a/chb/cmdline/jsonresultutil.py
+++ b/chb/cmdline/jsonresultutil.py
@@ -125,13 +125,9 @@ def function_invariants_to_json_result(
 
 def cfg_edge_to_json_result(
         f: "Function", src: str, tgt: str, kind: str) -> JSONResult:
-    # remove context from addresses
-    real_src = src.split("_")[-1] if src.startswith("F") else src
-    real_tgt = tgt.split("_")[-1] if tgt.startswith("F") else tgt
-
     content: Dict[str, Any] = {}
-    content["src"] = real_src
-    content["tgt"] = real_tgt
+    content["src"] = src
+    content["tgt"] = tgt
     content["kind"] = kind
     if kind in ["true", "false"]:
         if src in f.branchconditions:
@@ -151,6 +147,7 @@ def cfg_edge_to_json_result(
 
 def cfg_node_to_json_result(f: "Function", b: "BasicBlock") -> JSONResult:
     content: Dict[str, Any] = {}
+    content["id"] = b.baddr
     content["baddr"] = b.real_baddr
     bresult = b.to_json_result()
     if not bresult.is_ok:
@@ -209,13 +206,13 @@ def cfg_block_map_to_json_result(
     content: Dict[str, Any] = {}
     content["changes"] = blockra.changes()
     content["matches"] = blockra.matches()
-    content["cfg1-block-addr"] = blockra.b1.real_baddr
+    content["cfg1-block-addr"] = blockra.b1.baddr
     cfg2blocks: List[Dict[str, Any]] = []
     for (role, block2) in blockra.b2map.items():
         if len(blockra.b2map) == 1:
             role = "single-mapped"
         b2content: Dict[str, Any] = {}
-        b2content["cfg2-block-addr"] = block2.real_baddr
+        b2content["cfg2-block-addr"] = block2.baddr
         b2content["role"] = role
         cfg2blocks.append(b2content)
     content["cfg2-blocks"] = cfg2blocks

--- a/chb/jsoninterface/JSONControlFlowGraph.py
+++ b/chb/jsoninterface/JSONControlFlowGraph.py
@@ -46,6 +46,15 @@ class JSONCfgNode(JSONObject):
         return self.d.get("baddr", self.property_missing("baddr"))
 
     @property
+    def id(self) -> str:
+        """Returns the unique identifier for this cfg node.
+
+        This normally corresponds to BasicBlock.baddr, whereas baddr
+        above corresponds to BasicBlock.real_baddr.
+        """
+        return self.d.get("id", self.property_missing("id"))
+
+    @property
     def code(self) -> JSONAssemblyBlock:
         if self._code is None:
             self._code = JSONAssemblyBlock(self.d.get("code", {}))
@@ -91,8 +100,8 @@ class JSONCfgEdge(JSONObject):
 
     def accept(self, visitor: "JSONObjectVisitor") -> None:
         visitor.visit_cfg_edge(self)
-        
-    
+
+
 class JSONControlFlowGraph(JSONObject):
 
     def __init__(self, d: Dict[str, Any]) -> None:
@@ -132,6 +141,3 @@ class JSONControlFlowGraph(JSONObject):
 
     def accept(self, visitor: "JSONObjectVisitor") -> None:
         visitor.visit_control_flow_graph(self)
-    
-
-    


### PR DESCRIPTION
it is exposed as a new attribute, `id`, since it can be used to uniquely identify the block, whereas the pure address can be shared among many blocks in the presence of really weird instructions, such as `POPCC`.

This also switches the cfg edges to use the id/context address and not the bare bones address. And the same applies to the block mapping. The only place that wasn't changed was the list of blocks changed in FunctionRelationalAnalysis, that felt like a much bigger change and I wasn't sure it was needed.

Some whitespace changes snuck in because of my editor settings, apologies.