### PR TITLE
WIP: Typing fixes

### DIFF
--- a/chb/api/InterfaceDictionary.py
+++ b/chb/api/InterfaceDictionary.py
@@ -138,7 +138,7 @@ class InterfaceDictionary:
     def fts_parameter(self, ix: int) -> FtsParameter:
         return FtsParameter(self, self.fts_parameter_table.retrieve(ix))
 
-    def xpredicate(self, ix) -> XXPredicate:
+    def xpredicate(self, ix: int) -> XXPredicate:
         return apiregistry.mk_instance(
             self, self.xxpredicate_table.retrieve(ix), XXPredicate)
 

--- a/chb/app/Cfg.py
+++ b/chb/app/Cfg.py
@@ -582,7 +582,7 @@ class Cfg:
                     for succ in succs[1:]:
                       bodystmts.extend(switch_case_stmts(succ))
 
-                    # If the default case merely falls through, it can be omitted. 
+                    # If the default case merely falls through, it can be omitted.
                     defaultstmts = do_branch(x, succs[0], ctx)
                     if defaultstmts != []:
                       defaultcase = astree.mk_block(defaultstmts,

--- a/chb/app/FnXPODictionary.py
+++ b/chb/app/FnXPODictionary.py
@@ -74,7 +74,7 @@ class FnXPODictionary:
 
     # ------------------------------------------ retrieve items from tables ---
 
-    def xpo_predicate(self, ix) -> XPOPredicate:
+    def xpo_predicate(self, ix: int) -> XPOPredicate:
         if ix > 0:
             return xporegistry.mk_instance(
                 self, self.xpo_predicate_table.retrieve(ix), XPOPredicate)

--- a/chb/app/TrampolineInfo.py
+++ b/chb/app/TrampolineInfo.py
@@ -52,10 +52,10 @@ class TrampolineInfo:
     def roles(self) -> Dict[str, str]:
         return self._roles
 
-    def has_role(self, role) -> bool:
+    def has_role(self, role: str) -> bool:
         return role in self.roles
 
-    def get_role_startaddr(self, role) -> Optional[str]:
+    def get_role_startaddr(self, role: str) -> Optional[str]:
         return self.roles.get(role, None)
 
     def add_role(self, name: str, addr: str) -> None:

--- a/chb/app/XPOPredicate.py
+++ b/chb/app/XPOPredicate.py
@@ -289,6 +289,7 @@ class XPOEnum(XPOPredicate):
             self, xpod: "FnXPODictionary", ixval: IndexedTableValue) -> None:
         XPOPredicate.__init__(self, xpod, ixval)
 
+    @property
     def is_xpo_enum(self) -> bool:
         return True
 

--- a/chb/ast/AbstractSyntaxTree.py
+++ b/chb/ast/AbstractSyntaxTree.py
@@ -1218,13 +1218,13 @@ class AbstractSyntaxTree:
                 return e
 
         # Helpers to get a signed/unsigned version of a type
-        def withsign(ikind):
+        def withsign(ikind: str) -> str:
           if ikind.endswith("char"):
             return "ischar"
           if ikind.startswith("iu"):
             return "i" + ikind[2:]
           return ikind # already signed
-        def sanssign(ikind):
+        def sanssign(ikind: str) -> str:
           if ikind.endswith("char"):
             return "iuchar"
           if not ikind.startswith("iu"):

--- a/chb/ast/examples/store_struct_field.py
+++ b/chb/ast/examples/store_struct_field.py
@@ -38,7 +38,7 @@ from chb.ast.ASTSymbolTable import ASTGlobalSymbolTable, ASTLocalSymbolTable
 
 class ASTreeSetup:
 
-    def __init__(self, name: str, faddr="0x0") -> None:
+    def __init__(self, name: str, faddr: str = "0x0") -> None:
         self._astapi = ASTApplicationInterface()
         self._localsymboltable = ASTLocalSymbolTable(
             self._astapi.globalsymboltable)

--- a/chb/astinterface/ASTInterfaceFunction.py
+++ b/chb/astinterface/ASTInterfaceFunction.py
@@ -119,13 +119,13 @@ class ASTInterfaceFunction(ASTFunction):
         return self._patchevents
 
     @property
-    def jumptables(self) -> Dict[str,JumpTable]:
+    def jumptables(self) -> Dict[str, JumpTable]:
         return self.function.jumptables
 
-    def has_jumptable(self, tgt) -> bool:
+    def has_jumptable(self, tgt: str) -> bool:
         return tgt in self.jumptables
 
-    def get_jumptable(self, tgt) -> JumpTable:
+    def get_jumptable(self, tgt: str) -> JumpTable:
         if self.has_jumptable(tgt):
             return self.jumptables[tgt]
         else:

--- a/chb/cmdline/AnalysisManager.py
+++ b/chb/cmdline/AnalysisManager.py
@@ -77,8 +77,8 @@ class AnalysisManager(object):
             fns_include: List[str] = [],
             show_function_timing: bool = False,
             gc_compact: int = 0,
-            lineq_instr_cutoff = 0,
-            lineq_block_cutoff = 0,
+            lineq_instr_cutoff: int = 0,
+            lineq_block_cutoff: int = 0,
             use_ssa: bool = False,
             include_arm_extension_registers: bool = False,
             hints: Dict[str, Any] = {}) -> None:

--- a/chb/cmdline/runcmds.py
+++ b/chb/cmdline/runcmds.py
@@ -36,7 +36,7 @@ import time
 from contextlib import contextmanager
 from multiprocessing import Pool
 
-from typing import Any, cast, Dict, List, NoReturn, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Iterator, cast, Dict, List, NoReturn, Optional, Tuple, TYPE_CHECKING
 
 import chb.app.AppAccess as AP
 import chb.cmdline.commandutil as UC
@@ -61,7 +61,7 @@ def do_cmd(cmd: Tuple[Optional[str], List[str]]) -> Tuple[List[str], int]:
 
 
 @contextmanager
-def timing(activity):
+def timing(activity: str) -> Iterator[None]:
     t0 = time.time()
     yield
     print(

--- a/chb/cmdline/structcmds.py
+++ b/chb/cmdline/structcmds.py
@@ -192,7 +192,7 @@ class StructureClassification:
         self._baserhss: Dict[str, Dict[str, int]] = {}
         self._datastructures: Dict[str, DataStructure] = {}
 
-    def add_function(self, faddr) -> None:
+    def add_function(self, faddr: str) -> None:
         if not faddr in self.functions:
             self._functions[faddr] = StructuredFunction(faddr)
 

--- a/chb/cmdline/testcmds.py
+++ b/chb/cmdline/testcmds.py
@@ -35,7 +35,7 @@ import time
 from contextlib import contextmanager
 from multiprocessing import Pool
 
-from typing import Any, cast, Dict, List, NoReturn, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Iterator, cast, Dict, List, NoReturn, Optional, Tuple, TYPE_CHECKING
 
 import chb.app.AppAccess as AP
 import chb.cmdline.commandutil as UC
@@ -258,7 +258,7 @@ def analyze_x(cmdline: List[str]) -> Tuple[str, int]:
 
 
 @contextmanager
-def timing(activity):
+def timing(activity: str) -> Iterator[None]:
     t0 = time.time()
     yield
     print(

--- a/chb/elfformat/ELFHeader.py
+++ b/chb/elfformat/ELFHeader.py
@@ -329,13 +329,13 @@ class ELFHeader:
         else:
             raise UF.CHBError("Section " + str(index) + " not found")
 
-    def get_word_value(self, index: int, addr: int, little_endian=True) -> int:
+    def get_word_value(self, index: int, addr: int, little_endian: bool = True) -> int:
         if index in self.sections:
             return self.sections[index].get_word_value(addr, little_endian)
         else:
             raise UF.CHBError("Section " + str(index) + " not found")
 
-    def get_doubleword_value(self, index: int, addr: int, little_endian=True) -> int:
+    def get_doubleword_value(self, index: int, addr: int, little_endian: bool = True) -> int:
         if index in self.sections:
             return self.sections[index].get_doubleword_value(addr, little_endian)
         else:

--- a/chb/elfformat/ELFSection.py
+++ b/chb/elfformat/ELFSection.py
@@ -174,7 +174,7 @@ class ELFSection:
         else:
             raise UF.CHBError("Address not found in section " + self.name)
 
-    def get_word_value(self, address: int, little_endian=True) -> int:
+    def get_word_value(self, address: int, little_endian: bool = True) -> int:
         if address in self.values:
             b1 = self.get_byte_value(address)
             b2 = self.get_byte_value(address + 1)
@@ -185,7 +185,7 @@ class ELFSection:
         else:
             raise UF.CHBError("Word address not found in section " + self.name)
 
-    def get_doubleword_value(self, address: int, little_endian=True) -> int:
+    def get_doubleword_value(self, address: int, little_endian: bool = True) -> int:
         if address in self.values:
             b1 = self.get_byte_value(address)
             b2 = self.get_byte_value(address + 1)

--- a/chb/elfformat/ELFSectionHeader.py
+++ b/chb/elfformat/ELFSectionHeader.py
@@ -194,7 +194,7 @@ class ELFSectionHeader:
     def is_initialized(self) -> bool:
         return not(self.section_header_type == "SHT_NoBits")
 
-    def is_address_in_section(self, addr: int):
+    def is_address_in_section(self, addr: int) -> bool:
         if self.section_header_type == "SHT_ProgBits":
             vaddr_i = int(self.vaddr, 16)
             eaddr_i = vaddr_i + int(self.size, 16)

--- a/chb/jsoninterface/JSONObject.py
+++ b/chb/jsoninterface/JSONObject.py
@@ -48,7 +48,7 @@ class JSONObject(ABC):
     def objname(self) -> str:
         return self._objname
 
-    def property_missing(self, propname) -> str:
+    def property_missing(self, propname: str) -> str:
         return "missing:" + self.objname + ":" + propname
 
     @abstractmethod

--- a/chb/models/BTerm.py
+++ b/chb/models/BTerm.py
@@ -91,7 +91,7 @@ class BTerm:
     def refers_to_parameter(self, name: str) -> bool:
         return False
 
-    def parameter_refs(self, name) -> List[str]:
+    def parameter_refs(self, name: str) -> List[str]:
         return []
 
 
@@ -140,7 +140,7 @@ class BTermRuntimeValue(BTerm):
             xnode: Optional[ET.Element] = None) -> None:
         BTerm.__init__(self, fsem, tag, xnode)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.tag
 
 

--- a/chb/models/FunctionPrecondition.py
+++ b/chb/models/FunctionPrecondition.py
@@ -326,7 +326,7 @@ class PreRelationalCondition(FunctionPrecondition):
                 btermregistry.mk_instance(self.semantics, self.xterm(1), BTerm))
         return self._arg2
 
-    def refers_to_parameter(self, name) -> bool:
+    def refers_to_parameter(self, name: str) -> bool:
         return (
             self.arg1.refers_to_parameter(name)
             or self.arg2.refers_to_parameter(name))

--- a/chb/relational/CfgMatcher.py
+++ b/chb/relational/CfgMatcher.py
@@ -132,25 +132,25 @@ class CfgMatcher:
     def same_endianness(self) -> bool:
         return self.app1.header.is_big_endian == self.app2.header.is_big_endian
 
-    def src1post(self, src1) -> List[str]:
+    def src1post(self, src1: str) -> List[str]:
         if src1 in self._src1map:
             return self._src1map[src1]
         else:
             return []
 
-    def src2post(self, src2) -> List[str]:
+    def src2post(self, src2: str) -> List[str]:
         if src2 in self._src2map:
             return self._src2map[src2]
         else:
             return []
 
-    def tgt1pre(self, tgt1) -> List[str]:
+    def tgt1pre(self, tgt1: str) -> List[str]:
         if tgt1 in self._tgt1map:
             return self._tgt1map[tgt1]
         else:
             return []
 
-    def tgt2pre(self, tgt2) -> List[str]:
+    def tgt2pre(self, tgt2: str) -> List[str]:
         if tgt2 in self._tgt2map:
             return self._tgt2map[tgt2]
         else:

--- a/chb/simulation/SimDeserializer.py
+++ b/chb/simulation/SimDeserializer.py
@@ -100,7 +100,7 @@ def json_to_simval(d: Dict[str, Any]) -> SV.SimValue:
         raise UF.CHBError("No deserialization implemented yet for id = " + id)
 
 
-def byte_from_dw(dw: SV.SimDoubleWordValue, pos: int, bigendian=False) -> int:
+def byte_from_dw(dw: SV.SimDoubleWordValue, pos: int, bigendian: bool = False) -> int:
     if dw.is_defined:
         if bigendian:
             if pos == 0:

--- a/chb/tests/ELFThumbDisassemblyTestSet.py
+++ b/chb/tests/ELFThumbDisassemblyTestSet.py
@@ -121,7 +121,7 @@ class ELFThumbDisassemblyTestSet:
             cmd, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
         return result
 
-    def run(self):
+    def run(self) -> None:
         for r in tests:
             self.create_test(r)
             self.run_test(r)

--- a/chb/userdata/UserBType.py
+++ b/chb/userdata/UserBType.py
@@ -44,10 +44,10 @@ class UserBTypeStore:
     def add_typedef(self, name: str, t: "UserBType") -> None:
         self._typedefs[name] = t
 
-    def has_named_type(self, name) -> bool:
+    def has_named_type(self, name: str) -> bool:
         return name in self._basetypes or name in self._typedefs
 
-    def has_size_of(self, name) -> bool:
+    def has_size_of(self, name: str) -> bool:
         if name in self._basetypes:
             return True
         else:
@@ -62,7 +62,7 @@ class UserBTypeStore:
         else:
             raise UF.CHBError("Size of named type: " + name + " not found")
 
-    def _initialize(self, namedtypes) -> None:
+    def _initialize(self, namedtypes: Dict[str, int]) -> None:
         for (name, size) in namedtypes.items():
             self._basetypes[name] = UserNamedBType(name, size=size)
 
@@ -165,7 +165,7 @@ class UserPointerBType(UserBType):
 
 class UserArrayBType(UserBType):
 
-    def __init__(self, tgt: UserBType, num_elements) -> None:
+    def __init__(self, tgt: UserBType, num_elements: int) -> None:
         self._tgt = tgt
         self._num_elements = num_elements
 

--- a/chb/util/ConfigLocal.template
+++ b/chb/util/ConfigLocal.template
@@ -35,8 +35,13 @@ any of that config's variables here if you want to use a value other than the de
 """
 
 import os
+from typing import TYPE_CHECKING
 
-def getLocals(config):
+if TYPE_CHECKING:
+    from chb.util.Config import Config
+
+
+def getLocals(config: 'Config') -> None:
     '''Set local configuration variables here if they differ from the defaults in Config.py
     
     # Example :

--- a/chb/util/loggingutil.py
+++ b/chb/util/loggingutil.py
@@ -28,7 +28,7 @@
 
 import logging
 from enum import Enum
-from typing import Optional, Union
+from typing import Optional, List
 
 
 class LogLevel(str, Enum):
@@ -44,12 +44,12 @@ class LogLevel(str, Enum):
     debug = "DEBUG"
 
     @classmethod
-    def all(cls):
+    def all(cls) -> List['LogLevel']:
         return [x for x in cls]
 
     @classmethod
-    def options(cls):
-        return [x for x in cls] + ["NONE"]
+    def options(cls) -> List[str]:
+        return [x.value for x in cls] + ["NONE"]
 
 
 class CHKLogger:
@@ -66,7 +66,7 @@ class CHKLogger:
             self,
             initmsg: str = "",
             level: str = LogLevel.warning,
-            logfilename: str = None,
+            logfilename: Optional[str] = None,
             mode: str = "a") -> None:
 
         if not level in LogLevel.all():


### PR DESCRIPTION
Slowly working through fixing some minor typing issues in CH.

Some of these required adding a local `mypy.ini` file for mypy to complain:
```
[mypy]

# Options to make the checking stricter.
check_untyped_defs = True
disallow_untyped_defs = True
disallow_untyped_calls = True
```

I did not add that file to this branch yet.

Currently, I still have these mypy errors which will require a bit more work to fix:
```
chb/app/Cfg.py:578: error: Function is missing a type annotation  [no-untyped-def]
chb/app/Cfg.py:583: error: Call to untyped function "switch_case_stmts" in typed context  [no-untyped-call]
chb/tests/ELFThumbDisassemblyTestSet.py:54: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
chb/tests/ELFThumbDisassemblyTestSet.py:66: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
chb/tests/ELFThumbDisassemblyTestSet.py:72: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
chb/tests/ELFThumbDisassemblyTestSet.py:78: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
Found 6 errors in 2 files (checked 779 source files)
```

I'm using mypy version 1.10.0 locally.