### PR TITLE
Add minimal setup.py file to make chb pip installable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup, find_namespace_packages
+
+setup(
+    name="chb",
+    packages=find_namespace_packages(),
+    include_package_data=True,
+    zip_safe=False,
+    entry_points={},
+    install_requires=[],
+)


### PR DESCRIPTION
With this in place, we can do:

```
pip install -e chb@git+https://github.com/static-analysis-engineering/CodeHawk-Binary.git
```

instead of having to mess with `$PYTHONPATH`.

The `-e` installs it in editable mode so pip will download new versions as they become available (at least in theory!).