### PR TITLE
Initial support for header addresses on loops

### DIFF
--- a/chb/app/Cfg.py
+++ b/chb/app/Cfg.py
@@ -501,11 +501,13 @@ class Cfg:
                     if len(merges) == 1:
                         loopstmts = node_within(x, [], ctx.in_loop(x, break_to=merges[0]))
                         loop = cast(AST.ASTStmt, astree.mk_loop(mk_block(loopstmts),
-                                                                mergeaddr=merges[0]))
+                                                                mergeaddr=merges[0],
+                                                                continueaddr=x))
                         return [loop] + do_tree(merges[0], ctx)
                     else:
                         loopstmts = node_within(x, merges, ctx.in_loop(x, break_to=ctx.fallthrough))
-                        return [astree.mk_loop(mk_block(loopstmts), mergeaddr=ctx.fallthrough)]
+                        return [astree.mk_loop(mk_block(loopstmts), mergeaddr=ctx.fallthrough,
+                                                                    continueaddr=x)]
 
                 return node_within(x, merges, ctx)
 

--- a/chb/ast/ASTDeserializer.py
+++ b/chb/ast/ASTDeserializer.py
@@ -789,9 +789,13 @@ class ASTDeserializer:
             elif tag == "loop":
                 stmtid = r["stmtid"]
                 locationid = r["locationid"]
+                breakaddr = r.get("merge-addr")
+                continueaddr = r.get("continue-addr")
                 body = cast(AST.ASTStmt, mk_node(arg(0)))
                 nodes[id] = astree.mk_loop(
-                    body, optstmtid=stmtid, optlocationid=locationid)
+                    body,
+                    mergeaddr=breakaddr, continueaddr=continueaddr,
+                    optstmtid=stmtid, optlocationid=locationid)
 
             elif tag == "label":
                 locationid = r["locationid"]

--- a/chb/ast/ASTNode.py
+++ b/chb/ast/ASTNode.py
@@ -408,10 +408,12 @@ class ASTLoop(ASTStmt):
             stmtid: int,
             locationid: int,
             breakaddr: Optional[str],
+            continueaddr: Optional[str],
             body: "ASTStmt") -> None:
         ASTStmt.__init__(self, stmtid, locationid, [], "loop")
         self._body = body
         self._breakaddr = breakaddr
+        self._continueaddr = continueaddr
 
     @property
     def is_ast_loop(self) -> bool:
@@ -424,6 +426,10 @@ class ASTLoop(ASTStmt):
     @property
     def breakaddr(self) -> Optional[str]:
         return self._breakaddr
+
+    @property
+    def continueaddr(self) -> Optional[str]:
+        return self._continueaddr
 
     def accept(self, visitor: "ASTVisitor") -> None:
         visitor.visit_loop_stmt(self)

--- a/chb/ast/ASTSerializer.py
+++ b/chb/ast/ASTSerializer.py
@@ -353,6 +353,7 @@ class ASTSerializer(ASTIndexer):
         node["stmtid"] = stmt.stmtid
         node["locationid"] = stmt.locationid
         node["merge-addr"] = stmt.breakaddr
+        node["continue-addr"] = stmt.continueaddr
         return self.add(tags, args, node)
 
     def index_branch_stmt(self, stmt: AST.ASTBranch) -> int:

--- a/chb/ast/AbstractSyntaxTree.py
+++ b/chb/ast/AbstractSyntaxTree.py
@@ -363,11 +363,12 @@ class AbstractSyntaxTree:
             self,
             body: AST.ASTStmt,
             mergeaddr: Optional[str] = None,
+            continueaddr: Optional[str] = None,
             optstmtid: Optional[int] = None,
             optlocationid: Optional[int] = None) -> AST.ASTLoop:
         stmtid = self.get_stmtid(optstmtid)
         locationid = self.get_locationid(optlocationid)
-        return AST.ASTLoop(stmtid, locationid, mergeaddr, body)
+        return AST.ASTLoop(stmtid, locationid, mergeaddr, continueaddr, body)
 
     def mk_break_stmt(
             self,

--- a/chb/ast/doc/api.md
+++ b/chb/ast/doc/api.md
@@ -74,6 +74,7 @@ not present a new value is generated automatically.
     self,
     body: AST.ASTStmt,
     mergeaddr: Optional[str] = None,
+    continueaddr: Optional[str] = None,
     stmtid: Optional[int] = None,
     locationid: Optional[int] = None) -> AST.ASTLoop
   ```

--- a/chb/astinterface/ASTICodeTransformer.py
+++ b/chb/astinterface/ASTICodeTransformer.py
@@ -62,7 +62,8 @@ class ASTICodeTransformer(ASTIdentityTransformer):
     def transform_loop_stmt(self, stmt: AST.ASTLoop) -> AST.ASTStmt:
         newbody = stmt.body.transform(self)
         return self.astinterface.mk_loop(
-            newbody, mergeaddr=stmt.breakaddr, optlocationid=stmt.locationid)
+            newbody, mergeaddr=stmt.breakaddr, continueaddr=stmt.continueaddr,
+            optlocationid=stmt.locationid)
 
     def transform_block_stmt(self, stmt: AST.ASTBlock) -> AST.ASTStmt:
         newstmts = [s.transform(self) for s in stmt.stmts]

--- a/chb/astinterface/ASTInterface.py
+++ b/chb/astinterface/ASTInterface.py
@@ -625,8 +625,11 @@ class ASTInterface:
             self,
             body: AST.ASTStmt,
             mergeaddr: Optional[str] = None,
+            continueaddr: Optional[str] = None,
             optlocationid: Optional[int] = None) -> AST.ASTLoop:
-        return self.astree.mk_loop(body, mergeaddr=mergeaddr, optlocationid=optlocationid)
+        return self.astree.mk_loop(body, mergeaddr=mergeaddr,
+                                   continueaddr=continueaddr,
+                                   optlocationid=optlocationid)
 
     def mk_return_stmt(
             self,


### PR DESCRIPTION
The address of the loop header is used as the target of user-written `continue` statements.