### PR TITLE
fix warnings emitted by python3.12

### DIFF
--- a/chb/simulation/SimUtil.py
+++ b/chb/simulation/SimUtil.py
@@ -452,7 +452,7 @@ def extract_format_items(s: str) -> List[Tuple[int, str]]:
     https://stackoverflow.com/questions/30011379/how-can-i-parse-a-c-format-string-in-python
     """
 
-    cfmt = '''\
+    cfmt = r'''
     (                                  # start of capture group 1
     %                                  # literal "%"
     (?:                                # first option

--- a/chb/util/DotGraph.py
+++ b/chb/util/DotGraph.py
@@ -35,12 +35,12 @@ max_label_length = 2000
 def sanitize(s: str) -> str:
     if s is not None:
         return s.replace(
-            '>', "\>").replace(
+            '>', "\\>").replace(
                 '"', '\\"').replace(
-                    '%', "\%").replace(
-                        "<", "\<").replace(
-                            "{", "\{").replace(
-                                "}", "\}")
+                    '%', "\\%").replace(
+                        "<", "\\<").replace(
+                            "{", "\\{").replace(
+                                "}", "\\}")
 
 
 class DotNode:


### PR DESCRIPTION
when I started using python3.12 I got these warnings:
```
chb/util/DotGraph.py:38: SyntaxWarning: invalid escape sequence '\>'
  '>', "\>").replace(
chb/util/DotGraph.py:40: SyntaxWarning: invalid escape sequence '\%'
  '%', "\%").replace(
chb/util/DotGraph.py:41: SyntaxWarning: invalid escape sequence '\<'
  "<", "\<").replace(
chb/util/DotGraph.py:42: SyntaxWarning: invalid escape sequence '\{'
  "{", "\{").replace(
chb/util/DotGraph.py:43: SyntaxWarning: invalid escape sequence '\}'
  "}", "\}")
chb/simulation/SimUtil.py:455: SyntaxWarning: invalid escape sequence '\d'
  cfmt = '''\
```