### PR TITLE
Generate block-mapping for trampoline with continue statement

### DIFF
--- a/chb/cmdline/chkx
+++ b/chb/cmdline/chkx
@@ -1328,6 +1328,19 @@ def parse() -> argparse.Namespace:
         help="name of patch results file (required if there are trampolines)")
     relationalcompareall.add_argument(
         "--output", "-o", help="save json output in file")
+    relationalcompareall.add_argument(
+        "--loglevel", "-log",
+        choices=UL.LogLevel.options(),
+        default="NONE",
+        help="activate logging with the given level (default to stderr)")
+    relationalcompareall.add_argument(
+        "--logfilename",
+        help="name of file to write log messages")
+    relationalcompareall.add_argument(
+        "--logfilemode",
+        choices=["a", "w"],
+        default="a",
+        help="file mode for log file: append (a, default), or write (w)")
     relationalcompareall.set_defaults(func=R.relational_compare_all_cmd)
 
     # --- relational compare app --
@@ -1343,6 +1356,19 @@ def parse() -> argparse.Namespace:
         help="name of patch results file (required if there are trampolines)")
     relationalcomparefns.add_argument(
         "--output", "-o", help="save output in file")
+    relationalcompareall.add_argument(
+        "--loglevel", "-log",
+        choices=UL.LogLevel.options(),
+        default="NONE",
+        help="activate logging with the given level (default to stderr)")
+    relationalcompareall.add_argument(
+        "--logfilename",
+        help="name of file to write log messages")
+    relationalcompareall.add_argument(
+        "--logfilemode",
+        choices=["a", "w"],
+        default="a",
+        help="file mode for log file: append (a, default), or write (w)")
     relationalcomparefns.set_defaults(func=R.relational_compare_app_cmd)
 
     # --- relational compare function --

--- a/chb/cmdline/relationalcmds.py
+++ b/chb/cmdline/relationalcmds.py
@@ -324,6 +324,9 @@ def _relational_compare_generate_json(xname1: str,
                                       xpatchresults: Optional[str],
                                       usermappingfile: Optional[str],
                                       addresses: List[str],
+                                      loglevel: str,
+                                      logfilename: Optional[str],
+                                      logfilemode: str,
                                      ) -> JSONResult:
     try:
         (path1, xfile1) = UC.get_path_filename(xname1)
@@ -333,6 +336,13 @@ def _relational_compare_generate_json(xname1: str,
     except UF.CHBError as e:
         print(str(e.wrap()))
         exit(1)
+
+    UC.set_logging(
+        loglevel,
+        path1,
+        logfilename=logfilename,
+        mode=logfilemode,
+        msg="relational compare all")
 
     usermapping: Dict[str, str] = {}
     if usermappingfile is not None:
@@ -387,8 +397,13 @@ def relational_compare_all_cmd(args: argparse.Namespace) -> NoReturn:
     xpatchresults: Optional[str] = args.patch_results_file
     xoutput: str = args.output
     usermappingfile: Optional[str] = args.usermapping
+    loglevel: str = args.loglevel
+    logfilename: Optional[str] = args.logfilename
+    logfilemode: str = args.logfilemode
 
-    result = _relational_compare_generate_json(xname1, xname2, xpatchresults, usermappingfile, [])
+    result = _relational_compare_generate_json(xname1, xname2, xpatchresults,
+                                               usermappingfile, [],
+                                               loglevel, logfilename, logfilemode)
     if result.is_ok:
         jsonresult = JU.jsonok("compareall", result.content)
         exitval = 0
@@ -418,8 +433,13 @@ def relational_compare_app_cmd(args: argparse.Namespace) -> NoReturn:
     xpatchresults: Optional[str] = args.patch_results_file
     xoutput: str = args.output
     usermappingfile: Optional[str] = args.usermapping
+    loglevel: str = args.loglevel
+    logfilename: Optional[str] = args.logfilename
+    logfilemode: str = args.logfilemode
 
-    result = _relational_compare_generate_json(xname1, xname2, xpatchresults, usermappingfile, [])
+    result = _relational_compare_generate_json(xname1, xname2, xpatchresults,
+                                               usermappingfile, [],
+                                               loglevel, logfilename, logfilemode)
     if not result.is_ok:
         print("ERROR: Couldn't generate app comparison results")
         exit(1)

--- a/chb/relational/FunctionRelationalAnalysis.py
+++ b/chb/relational/FunctionRelationalAnalysis.py
@@ -400,6 +400,9 @@ class FunctionRelationalAnalysis:
             trampoline = cast("ARMCfgTrampolineBlock", self.cfgtc_blocks2[b])
             tpre = trampoline.prenodes
             tpost = trampoline.postnodes
+            # Need this definition up here, otherwise mypy gets mad.
+            roles: Dict[str, "BasicBlock"] = {}
+
             if len(tpre) == 1 and len(tpost) == 1:
                 if (
                         tpre[0] in cfg2unmapped
@@ -407,7 +410,6 @@ class FunctionRelationalAnalysis:
                         and tpre[0] in cfg1unmapped):
                     # Case where trampoline has an early return and a fallthrough case
                     # (what we mark as the exit block)
-                    roles: Dict[str, "BasicBlock"] = {}
                     roles["entry"] = self.basic_blocks2[tpre[0]]
                     roles["exit"] = self.basic_blocks2[tpost[0]]
                     for (role, addr) in trampoline.roles.items():
@@ -447,7 +449,6 @@ class FunctionRelationalAnalysis:
                                            fallthrough.baddr, fallthrough_post)
                     return
 
-                roles: Dict[str, "BasicBlock"] = {}
                 roles["entry"] = self.basic_blocks2[tpre[0]]
                 roles["exit"] = self.basic_blocks2[fallthrough_post[0]]
                 for (role, addr) in trampoline.roles.items():

--- a/chb/relational/FunctionRelationalAnalysis.py
+++ b/chb/relational/FunctionRelationalAnalysis.py
@@ -27,16 +27,14 @@
 """Compares two related functions in two binaries."""
 
 from typing import (
-    Any, cast, Dict, List, Mapping, Optional, Set, Tuple, TYPE_CHECKING)
+    Any, cast, Dict, List, Mapping, Optional, Set, Tuple, TYPE_CHECKING,
+)
 
 from chb.jsoninterface.JSONResult import JSONResult
 from chb.relational.BlockRelationalAnalysis import BlockRelationalAnalysis
-from chb.relational.InstructionRelationalAnalysis import (
-    InstructionRelationalAnalysis)
 from chb.relational.CfgMatcher import CfgMatcher
 
-import chb.util.fileutil as UF
-from chb.util.loggingutil import chklogger, LogLevel
+from chb.util.loggingutil import chklogger
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
The existing code didn't handle this case because in a continue statement
the trampoline block has two 'post' blocks.
    
This also adds code to report a warning when we find an unhandled trampoline case.
And adds logging support for `compare all` and `compare app`. And
gets rid of some unused imports.