### PR TITLE
fix bug when collecting compinfos for global types

### DIFF
--- a/chb/bctypes/BCFiles.py
+++ b/chb/bctypes/BCFiles.py
@@ -34,7 +34,7 @@ from chb.bctypes.BCCompInfo import BCCompInfo
 from chb.bctypes.BCDictionary import BCDictionary
 from chb.bctypes.BCEnumInfo import BCEnumInfo
 from chb.bctypes.BCFunctionDefinition import BCFunctionDefinition
-from chb.bctypes.BCTyp import BCTyp, BCTypComp
+from chb.bctypes.BCTyp import BCTyp, BCTypComp, BCTypNamed
 from chb.bctypes.BCTypeInfo import BCTypeInfo
 from chb.bctypes.BCVarInfo import BCVarInfo
 
@@ -81,6 +81,10 @@ class BCFiles:
     def fsum_compinfos(self) -> List[BCCompInfo]:
         result: List[BCCompInfo] = []
         for typ in self.gtypes:
+            if typ.is_typedef:
+                typedef = cast("BCTypNamed", typ).typedef
+                if typedef:
+                    typ = typ = cast("BCTypeInfo", typedef).ttype
             if typ.is_struct:
                 compinfo = cast("BCTypComp", typ).compinfo
                 result.append(compinfo)


### PR DESCRIPTION
a typedef will return True if its underlying type is a struct, but it does not also proxy compinfo, so we need to check for that case first, 'deref' (so to speak) the typedef, and then we should be able to access the compinfo

This seems to have been triggered by a header with this type definition in it:
```c
typedef struct ___sigset_t __sigset_t;
```

Which led to the following exception:
```
Traceback (most recent call last):
  File "CodeHawk-Binary/chb/cmdline/chkx", line 1691, in <module>
    args.func(args)
  File "CodeHawk-Binary/chb/cmdline/astcmds.py", line 234, in buildast
    for cinfo in app.bcfiles.fsum_compinfos:
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "CodeHawk-Binary/chb/bctypes/BCFiles.py", line 85, in fsum_compinfos
    compinfo = cast("BCTypComp", typ).compinfo
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'BCTypNamed' object has no attribute 'compinfo'
```
