### PR TITLE
Misc fixes

### DIFF
--- a/chb/arm/opcodes/ARMStoreRegisterHalfword.py
+++ b/chb/arm/opcodes/ARMStoreRegisterHalfword.py
@@ -194,6 +194,7 @@ class ARMStoreRegisterHalfword(ARMOpcode):
                 lhs, xdata, iaddr, astree, memaddr=memaddr)
 
         elif xd.is_vmem_unknown and xd.is_address_known:
+            lhs = None
             memaddr = xd.xaddr
             hl_lhs = XU.xmemory_dereference_lval(memaddr, xdata, iaddr, astree)
 
@@ -216,7 +217,7 @@ class ARMStoreRegisterHalfword(ARMOpcode):
             bytestring=bytestring,
             annotations=annotations)
 
-        if lhs.is_tmp:
+        if lhs is not None and lhs.is_tmp:
             astree.add_expose_instruction(hl_assign.instrid)
         astree.add_instr_mapping(hl_assign, ll_assign)
         astree.add_instr_address(hl_assign, [iaddr])
@@ -265,4 +266,4 @@ class ARMStoreRegisterHalfword(ARMOpcode):
             ll_assigns = [ll_assign]
             hl_assigns = [hl_assign]
 
-        return ([hl_assign], [ll_assign])
+        return (hl_assigns, ll_assigns)

--- a/chb/userdata/UserHints.py
+++ b/chb/userdata/UserHints.py
@@ -529,15 +529,16 @@ class StackVarIntro:
         """
 
         if not "offset" in self.varintro:
-            chklogger.logger.warning(
-                "Stack variable intro without offset; returning 0")
-        index = int(self.varintro.get("offset", "0"))
+            raise UF.CHBError(
+                "Stack variable intro without offset")
+
+        index = int(self.varintro["offset"])
         if index > 0:
             return -index
         else:
             raise UF.CHBError(
                 "Unexpected non-positive offset in stack-variable intro: "
-                + str(self.offset))
+                + str(index))
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
- Fix for infinite recursion when stack offset is not present in a stack variable introduction.
- Fix for possibly unbound variable in ARMStoreRegisterHalfword.py.
- Switch return value of ARMStoreRegisterHalfword:ast_prov to use variables that were being assigned to but not used. I'm not sure if this is correct though.