### PR TITLE
Small tweak to allow importing the CHB python code in windows

### DIFF
--- a/chb/util/Config.py
+++ b/chb/util/Config.py
@@ -29,6 +29,7 @@
 """Contains the locations of various components used by the analyzer."""
 
 import os
+import platform
 
 from typing import Any, Dict, List
 
@@ -44,10 +45,12 @@ class Config():
 
     def __init__(self) -> None:
         # platform settings
-        if os.uname()[0] == 'Linux':
+        if platform.uname()[0] == 'Linux':
             self.platform = 'linux'
-        elif os.uname()[0] == 'Darwin':
+        elif platform.uname()[0] == 'Darwin':
             self.platform = 'macOS'
+        else:
+            self.platform = "Unknown"
 
         # general settings
         self.utildir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
`os.uname` is not present in windows, but `platform.uname` is.

note that this only allows you to import the code in windows, depending on what functionality is needed, additional changes will be needed