### PR TITLE
CFG: always create a block even if it only has a single statement

### DIFF
--- a/chb/app/Cfg.py
+++ b/chb/app/Cfg.py
@@ -477,8 +477,6 @@ class Cfg:
         fn = astfn.function
 
         def mk_block(stmts: List[AST.ASTStmt]) -> AST.ASTStmt:
-            if len(stmts) == 1 and not stmts[0].is_ast_instruction_sequence:
-                return stmts[0]
             return astree.mk_block(stmts)
 
         gotolabels: Set[str] = set() # this is both used and mutated by run_with_gotolabels()


### PR DESCRIPTION
We want to be consistent and predictable, and avoid issues with CIL which normalizes statements into blocks within if/else, switch, and loops.

This also enables simplification for downstream tools