### PR TITLE
Revert "CFG: revert change for single-stmt block"

### DIFF
--- a/chb/app/Cfg.py
+++ b/chb/app/Cfg.py
@@ -477,8 +477,6 @@ class Cfg:
         fn = astfn.function
 
         def mk_block(stmts: List[AST.ASTStmt]) -> AST.ASTStmt:
-            if len(stmts) == 1 and not stmts[0].is_ast_instruction_sequence:
-                return stmts[0]
             return astree.mk_block(stmts)
 
         gotolabels: Set[str] = set() # this is both used and mutated by run_with_gotolabels()


### PR DESCRIPTION
This reverts commit 9f6af5af1203cbd28d0b61be87607ca9cfc1a4ec.

This is a revert of a revert of b406023245464e670ec4f774656cf03558a8b83e

b406023245464e670ec4f774656cf03558a8b83e was causing some regression test failures but that was because the patcher side of things had not been merged.