### PR TITLE
CMD: add chkx results check command

### DIFF
--- a/chb/app/CHVersion.py
+++ b/chb/app/CHVersion.py
@@ -1,3 +1,3 @@
-chbversion: str = "0.3.0-20260125"
+chbversion: str = "0.3.0-20260126"
 
 minimum_required_chb_version = "0.6.0_20260122"

--- a/chb/cmdline/chkx
+++ b/chb/cmdline/chkx
@@ -610,6 +610,11 @@ def parse() -> argparse.Namespace:
     resultscmd.set_defaults(func=resultscommand)
     resultsparsers = resultscmd.add_subparsers(title='show options')
 
+    # -- results check --
+    resultscheck = resultsparsers.add_parser("check")
+    resultscheck.add_argument("xname", help="name of executable")
+    resultscheck.set_defaults(func=UCC.results_check)
+
     # -- results stats --
     resultsstats = resultsparsers.add_parser('stats')
     resultsstats.add_argument('xname', help='name of executable')

--- a/chb/cmdline/commandutil.py
+++ b/chb/cmdline/commandutil.py
@@ -627,6 +627,36 @@ def analyzecmd(args: argparse.Namespace) -> NoReturn:
         exit(0)
 
 
+def results_check(args: argparse.Namespace) -> NoReturn:
+    """Checks if results present are compatible with the current version."""
+
+    # arguments
+    xname: str = str(args.xname)
+
+    try:
+        (path, xfile) = get_path_filename(xname)
+        UF.check_analysis_results(path, xfile)
+    except UF.CHBError as e:
+        print_error(str(e.wrap()))
+        exit(1)
+
+    chbversion = UF.get_resultmetrics_chb_version(path, xfile)
+    if chbversion >= minimum_required_chb_version:
+        print_status_update(
+            "Analysis results version: "
+            + chbversion
+            + " is compatible with minimum required version: "
+            + minimum_required_chb_version)
+        exit(0)
+    else:
+        print_error(
+            "Analysis results version: "
+            + chbversion
+            + " is not compatible with minimum required version: "
+            + minimum_required_chb_version)
+        exit(1)
+
+
 def results_stats(args: argparse.Namespace) -> NoReturn:
     """Prints out a summary of the analysis results per function."""
 
@@ -649,6 +679,15 @@ def results_stats(args: argparse.Namespace) -> NoReturn:
     except UF.CHBError as e:
         print_error(str(e.wrap()))
         exit(1)
+
+    chbversion = UF.get_resultmetrics_chb_version(path, xfile)
+    if chbversion < minimum_required_chb_version:
+        print_status_update(
+            "Warning: analysis results may be out of date. "
+            + "The version of the analysis results: "
+            + chbversion
+            + " is not compatible with the minimum required version: "
+            + minimum_required_chb_version)
 
     set_logging(
         loglevel,


### PR DESCRIPTION
Adds a CLI command
> chkx results check <filename>
to check if analysis are present, and if so, if these analysis results are still compatible with the current version of the analyzer.. If no results are present, or if the results are outdated, the command prints an error message to stderr and returns 1, otherwise the command prints a status update message to stderr and returns 0.