### PR TITLE
Add intermediate faddr for report patch candidates.

### DIFF
--- a/chb/buffer/LibraryCallCallsites.py
+++ b/chb/buffer/LibraryCallCallsites.py
@@ -25,7 +25,7 @@
 # SOFTWARE.
 # ------------------------------------------------------------------------------
 
-from typing import Any, cast, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, cast, Dict, List, Optional, Tuple, TYPE_CHECKING
 
 from chb.invariants.XConstant import XIntConst
 from chb.invariants.XNumerical import XNumerical
@@ -257,7 +257,7 @@ class LibraryCallSideeffect:
                        buffersize: int,
                        sizeorigin: str,
                        spare: Optional[str],
-                       intermediateinstr: Optional[str],
+                       intermediate: Optional[Tuple[str, str]],
                       ) -> JSONResult:
         if self.dstarg is None:
             chklogger.logger.warning(
@@ -278,8 +278,9 @@ class LibraryCallSideeffect:
         else:
             content["length-argument"] = None
         content["spare"] = spare
-        if intermediateinstr:
-            content['intermediate-iaddr'] = intermediateinstr
+        if intermediate:
+            content['intermediate-faddr'] = intermediate[0]
+            content['intermediate-iaddr'] = intermediate[1]
 
         return JSONResult("librarycallsideeffect", content, "ok")
 

--- a/chb/cmdline/reportcmds.py
+++ b/chb/cmdline/reportcmds.py
@@ -1437,7 +1437,11 @@ def report_patch_candidates(args: argparse.Namespace) -> NoReturn:
                 sizeorigin = "intermediate-" + sizeorigin
 
                 intermediate = (inter_func.faddr, inter_instr.iaddr)
-                jresult = pc.to_json_result(dstoffset, buffersize, sizeorigin, spare, intermediate)
+                jresult = pc.to_json_result(dstoffset,
+                                            buffersize,
+                                            sizeorigin,
+                                            spare,
+                                            intermediate)
                 if not jresult.is_ok:
                     chklogger.logger.warning("Couldn't process patch callsite %s", pc)
                     continue

--- a/chb/cmdline/reportcmds.py
+++ b/chb/cmdline/reportcmds.py
@@ -1436,7 +1436,8 @@ def report_patch_candidates(args: argparse.Namespace) -> NoReturn:
                     continue
                 sizeorigin = "intermediate-" + sizeorigin
 
-                jresult = pc.to_json_result(dstoffset, buffersize, sizeorigin, spare, inter_instr.iaddr)
+                intermediate = (inter_func.faddr, inter_instr.iaddr)
+                jresult = pc.to_json_result(dstoffset, buffersize, sizeorigin, spare, intermediate)
                 if not jresult.is_ok:
                     chklogger.logger.warning("Couldn't process patch callsite %s", pc)
                     continue


### PR DESCRIPTION
For assurances, it may be useful to have information about the intermediate function/callsite.